### PR TITLE
Add --keep-root and --max-iter to the treetime call

### DIFF
--- a/utilities/deltrans_intro_treetime.md
+++ b/utilities/deltrans_intro_treetime.md
@@ -4,7 +4,7 @@ If you don't have one already, you need a Grapevine conda environment:
 ```
 git clone https://github.com/COG-UK/grapevine.git
 cd grapevine
-conda install -f environment.yml
+conda env create -f environment.yml
 conda activate grapevine
 ```
 

--- a/utilities/deltrans_intro_treetime.nf
+++ b/utilities/deltrans_intro_treetime.nf
@@ -95,6 +95,8 @@ process treetime {
     --clock-rate 0.00100 \
     --clock-filter 0 \
     --tree sedded_tree.nexus \
+    --keep-root \
+    --max-iter 10 \
     --dates metadata.csv \
     --name-column sequence_name \
     --date-column sample_date \


### PR DESCRIPTION
Add keep-root and max-iter to the treetime call. 

**--keep-root:** By default treetime tries to find the best-fitting root by root-to-tip regression, but the subtrees are already rooted when we pull them out with clusterfunk. Not finding the best-fitting root speeds up treetime. 

**--max-iter:** treetime tries resolving polytomies a few times and selects the resolution that leads to the highest likelihood (in practice this resolves by date). By default maximum number of iterations seems to be set to 2, but from trail and error it looks like SARS-CoV-2 trees only converge on iteration 6 or 7. The first iteration usually takes the longest by far so this shouldn't increase running time too much. Alternatively insert --keep-polytomies to not resolve any polytomies (but this has other issues). 

If you choose to merge `rules/6_treetime.smk` probably also needs to be edited. 

I also changed `conda install -f environment.yml` which didn't work for me to `conda env create -f environment.yml` which did work.
